### PR TITLE
Entrypoint -> CMD and upgrade to 0.2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM java:8
 
 RUN apt-get update && apt-get install -y curl bzip2
-RUN curl https://aphyr.com/riemann/riemann-0.2.8.tar.bz2 | tar -C /opt -xj
+ENV VERSION 0.2.8
+RUN curl https://aphyr.com/riemann/riemann-${VERSION}.tar.bz2 | tar -C /opt -xj
 
 VOLUME ["/config"]
 
 EXPOSE 5555
 EXPOSE 5556
 
-ENTRYPOINT if [ -f /config/riemann.config ]; then CONF_PATH=/config/riemann.config ; else CONF_PATH=/opt/riemann-0.2.8/etc/riemann.config ; fi && \
-	   /opt/riemann-0.2.8/bin/riemann $CONF_PATH
+COPY start.sh ./
+CMD ./start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8
 
 RUN apt-get update && apt-get install -y curl bzip2
-ENV VERSION 0.2.8
+ENV VERSION 0.2.10
 RUN curl https://aphyr.com/riemann/riemann-${VERSION}.tar.bz2 | tar -C /opt -xj
 
 VOLUME ["/config"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ -f /config/riemann.config ]; then
+  CONF_PATH=/config/riemann.config
+else
+  CONF_PATH=/opt/riemann-${VERSION}/etc/riemann.config
+fi
+/opt/riemann-${VERSION}/bin/riemann $CONF_PATH


### PR DESCRIPTION
Thanks for this dockerfile! I've made a couple of changes here:
- Used CMD instead of ENTRYPOINT which lets you run Riemann tests more easily.
- Parameterised version number and upgraded to Riemann 0.2.10
